### PR TITLE
Fix notification dropdown alignment

### DIFF
--- a/components/NotificationBell.js
+++ b/components/NotificationBell.js
@@ -159,7 +159,7 @@ export default function NotificationBell({ chats, setCurrentChat, currentChat })
       </Button>
 
       {showNotifications && (
-        <Card className="absolute top-full right-0 mt-2 w-80 max-w-[90vw] z-50 shadow-lg border transform -translate-x-full md:-translate-x-0">
+        <Card className="absolute top-full right-0 mt-2 w-80 max-w-[90vw] z-50 shadow-lg border">
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-3">
               <h3 className="font-semibold text-sm">Notifications</h3>


### PR DESCRIPTION
## Summary
- ensure the notification dropdown doesn't shift off-screen

## Testing
- `npm run lint` *(fails: `next` not found)*