### PR TITLE
Add Jest tests

### DIFF
--- a/__tests__/NotificationBell.test.js
+++ b/__tests__/NotificationBell.test.js
@@ -1,0 +1,14 @@
+import { render, fireEvent, screen } from '@testing-library/react'
+import NotificationBell from '@/components/NotificationBell'
+
+jest.mock('@/components/AuthProvider', () => ({
+  useAuth: () => ({ user: { id: 'test-user' } })
+}))
+
+describe('NotificationBell', () => {
+  it('shows no notifications message when none are present', () => {
+    render(<NotificationBell chats={[]} currentChat={null} setCurrentChat={jest.fn()} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText(/No notifications/i)).toBeInTheDocument()
+  })
+})

--- a/__tests__/ai.test.js
+++ b/__tests__/ai.test.js
@@ -1,0 +1,51 @@
+import { getAIResponse } from '@/lib/utils/ai'
+
+describe('getAIResponse', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    delete process.env.NEXT_PUBLIC_USE_DIRECT_QUESTIONS
+  })
+
+  it('returns error for empty input', async () => {
+    const result = await getAIResponse('', { messages: [] })
+    expect(result).toEqual({ error: 'Cannot process empty input.' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns first tool question when direct mode enabled', async () => {
+    process.env.NEXT_PUBLIC_USE_DIRECT_QUESTIONS = 'true'
+    const result = await getAIResponse('', { tool_id: 'hybrid-offer', messages: [] })
+    expect(result.content).toMatch(/Welcome!/)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('streams response for regular chat', async () => {
+    const encoder = new TextEncoder()
+    const chunks = [encoder.encode('Hello'), encoder.encode(' World')]
+    let index = 0
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: {
+        getReader() {
+          return {
+            read() {
+              if (index < chunks.length) {
+                return Promise.resolve({ done: false, value: chunks[index++] })
+              }
+              return Promise.resolve({ done: true })
+            }
+          }
+        }
+      }
+    })
+
+    const result = await getAIResponse('Hi', { messages: [] })
+    expect(global.fetch).toHaveBeenCalled()
+    expect(result).toEqual({ content: 'Hello World', isStreamed: true })
+  })
+})

--- a/__tests__/supabase.test.js
+++ b/__tests__/supabase.test.js
@@ -1,0 +1,11 @@
+import { fetchThreads, getThreads, deleteThread } from '@/lib/utils/supabase'
+
+describe('supabase utils', () => {
+  it('fetchThreads is an alias for getThreads', () => {
+    expect(fetchThreads).toBe(getThreads)
+  })
+
+  it('deleteThread throws when id missing', async () => {
+    await expect(deleteThread()).rejects.toThrow('Thread ID is required')
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
@@ -40,6 +41,10 @@
     "eslint": "^8.56.0",
     "eslint-config-next": "14.1.0",
     "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library and test script
- configure Jest for Next.js
- write basic tests for utility modules and NotificationBell component

## Testing
- `npm test` *(fails: jest not found)*