### PR TITLE
Add threads table schema with Drizzle ORM

### DIFF
--- a/db/schema/index.js
+++ b/db/schema/index.js
@@ -1,4 +1,4 @@
 export * from "./threads-schema";
 export * from "./messages-schema";
 export * from "./profiles-schema";
-// Include any other schemas exported from this directory 
+// Include any other schemas exported from this directory

--- a/db/schema/threads-schema.js
+++ b/db/schema/threads-schema.js
@@ -1,0 +1,21 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const threadsTable = pgTable("threads", {
+  id: text("id").defaultRandom().primaryKey(),
+  title: text("title").notNull(),
+  user_id: text("user_id").notNull(),
+  tool_id: text("tool_id"),
+  metadata: text("metadata"),
+  created_at: timestamp("created_at").defaultNow().notNull(),
+  updated_at: timestamp("updated_at")
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date())
+});
+
+export const getThreadsTableWithTypescript = () => {
+  return {
+    $inferInsert: {},
+    $inferSelect: {}
+  };
+};


### PR DESCRIPTION
## Summary
- define `threadsTable` in `db/schema/threads-schema.js`
- export new schema from `db/schema/index.js`

## Testing
- `npm run lint` *(fails: `next` not found)*