### PR TITLE
Refactor Supabase initialization

### DIFF
--- a/app/api/assistant-status/route.js
+++ b/app/api/assistant-status/route.js
@@ -1,5 +1,4 @@
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { OpenAI } from 'openai';
 
@@ -23,24 +22,7 @@ export async function POST(request) {
     console.log(`[Assistant Status] Checking run status: ${runId} for thread: ${threadId}`);
     
     // Setup Supabase client
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      {
-        cookies: {
-          get(name) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name, value, options) {
-            cookieStore.set({ name, value, ...options });
-          },
-          remove(name, options) {
-            cookieStore.set({ name, value: '', ...options });
-          },
-        },
-      }
-    );
+    const supabase = createClient();
     
     // Check the run status
     const runStatus = await openai.beta.threads.runs.retrieve(threadId, runId);

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -1,7 +1,6 @@
 import { OpenAI } from 'openai';
 import Anthropic from '@anthropic-ai/sdk';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { TOOLS } from '@/lib/config/tools';
 import { v4 as uuidv4 } from 'uuid';
@@ -1155,18 +1154,7 @@ export async function POST(request) {
     }
 
     // Initialize Supabase client early, before any operations that might use it
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      {
-        cookies: {
-          get(name) { return cookieStore.get(name)?.value; },
-          set(name, value, options) { cookieStore.set({ name, value, ...options }); },
-          remove(name, options) { cookieStore.set({ name, value: '', ...options }); },
-        },
-      }
-    );
+    const supabase = createClient();
 
     // Get the authenticated user
     const { data: { user } } = await supabase.auth.getUser();

--- a/app/api/debug/route.js
+++ b/app/api/debug/route.js
@@ -1,28 +1,10 @@
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 
 export async function GET(request) {
   try {
     // Setup Supabase client
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      {
-        cookies: {
-          get(name) {
-            return cookieStore.get(name)?.value;
-          },
-          set(name, value, options) {
-            cookieStore.set({ name, value, ...options });
-          },
-          remove(name, options) {
-            cookieStore.set({ name, value: '', ...options });
-          },
-        },
-      }
-    );
+    const supabase = createClient();
 
     // Get all threads with their messages
     const { data: threads, error: threadsError } = await supabase

--- a/app/api/update-thread-metadata/route.js
+++ b/app/api/update-thread-metadata/route.js
@@ -1,28 +1,6 @@
 import { NextResponse } from 'next/server';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
 
-const createSupabaseClient = () => {
-  const cookieStore = cookies();
-  
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    {
-      cookies: {
-        get(name) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name, value, options) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name, options) {
-          cookieStore.set({ name, value: '', ...options });
-        },
-      },
-    }
-  );
-};
 
 export async function POST(request) {
   try {
@@ -34,7 +12,7 @@ export async function POST(request) {
     
     console.log('[Update Thread Metadata] Updating thread:', threadId, 'with metadata:', metadata);
     
-    const supabase = createSupabaseClient();
+    const supabase = createClient();
     
     // First, try to find the thread
     const { data: existingThread, error: findError } = await supabase

--- a/app/auth/callback/route.js
+++ b/app/auth/callback/route.js
@@ -1,5 +1,4 @@
-import { createServerClient } from '@supabase/ssr'
-import { cookies } from 'next/headers'
+import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 
 export async function GET(request) {
@@ -13,24 +12,7 @@ export async function GET(request) {
   console.log(`[Auth Callback] Has code: ${!!code}`);
 
   if (code) {
-    const cookieStore = cookies()
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      {
-        cookies: {
-          get(name) {
-            return cookieStore.get(name)?.value
-          },
-          set(name, value, options) {
-            cookieStore.set({ name, value, ...options })
-          },
-          remove(name, options) {
-            cookieStore.set({ name, value: '', ...options })
-          },
-        },
-      }
-    )
+    const supabase = createClient()
     
     console.log(`[Auth Callback] Exchanging code for session`);
     const { error } = await supabase.auth.exchangeCodeForSession(code)

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,4 @@
-import { createServerClient } from '@supabase/ssr'
+import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 
 export async function middleware(request) {
@@ -8,51 +8,7 @@ export async function middleware(request) {
     },
   })
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    {
-      cookies: {
-        get(name) {
-          return request.cookies.get(name)?.value
-        },
-        set(name, value, options) {
-          request.cookies.set({
-            name,
-            value,
-            ...options,
-          })
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          })
-          response.cookies.set({
-            name,
-            value,
-            ...options,
-          })
-        },
-        remove(name, options) {
-          request.cookies.set({
-            name,
-            value: '',
-            ...options,
-          })
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          })
-          response.cookies.set({
-            name,
-            value: '',
-            ...options,
-          })
-        },
-      },
-    }
-  )
+  const supabase = createClient()
 
   await supabase.auth.getSession()
 


### PR DESCRIPTION
## Summary
- use shared `createClient` helper for Supabase in API handlers and middleware
- remove duplicated cookie logic

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*