### PR TITLE
Integrate SSE cleanup hook and fix ChatArea

### DIFF
--- a/hooks/use-chat-sse.js
+++ b/hooks/use-chat-sse.js
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRef } from "react";
+
+export default function useChatSSE() {
+  const eventSourceRef = useRef(null);
+
+  const closeConnection = () => {
+    if (eventSourceRef.current) {
+      try {
+        eventSourceRef.current.close();
+      } catch (err) {
+        if (process.env.NODE_ENV !== "production") console.error("[useChatSSE] Error closing SSE", err);
+      }
+      eventSourceRef.current = null;
+    }
+  };
+
+  return { eventSourceRef, closeConnection };
+}


### PR DESCRIPTION
## Summary
- add `useChatSSE` hook for managing EventSource connections
- use `useChatSSE` in ChatArea and close connections on unmount or chat change

## Testing
- `npm test` *(fails: TextEncoder is not defined)*