### PR TITLE
Add profile fields to schema and migration

### DIFF
--- a/db/schema/profiles-schema.js
+++ b/db/schema/profiles-schema.js
@@ -3,6 +3,10 @@ import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 export const userProfilesTable = pgTable("user_profiles", {
   id: text("id").defaultRandom().primaryKey(),
   user_id: text("user_id").notNull().unique(),
+  full_name: text("full_name"),
+  occupation: text("occupation"),
+  desired_mrr: text("desired_mrr"),
+  desired_hours: text("desired_hours"),
   business_name: text("business_name"),
   business_type: text("business_type"),
   target_audience: text("target_audience"),

--- a/supabase/migrations/20240601000000_add_profile_context.sql
+++ b/supabase/migrations/20240601000000_add_profile_context.sql
@@ -1,0 +1,5 @@
+-- Add new columns to store user profile context
+alter table public.user_profiles add column full_name text;
+alter table public.user_profiles add column occupation text;
+alter table public.user_profiles add column desired_mrr text;
+alter table public.user_profiles add column desired_hours text;


### PR DESCRIPTION
## Summary
- extend profiles schema with new fields: `full_name`, `occupation`, `desired_mrr`, and `desired_hours`
- create migration to add these columns to `user_profiles`

## Testing
- `npm test` *(fails: ReferenceError nextQuestion is not defined)*