### PR TITLE
Add profile API route

### DIFF
--- a/app/api/profile/route.js
+++ b/app/api/profile/route.js
@@ -1,0 +1,75 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+function createSupabaseClient() {
+  const cookieStore = cookies()
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        set(name, value, options) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name, options) {
+          cookieStore.set({ name, value: '', ...options })
+        }
+      }
+    }
+  )
+}
+
+export async function GET() {
+  const supabase = createSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('full_name, occupation, desired_mrr, desired_hours')
+    .eq('id', user.id)
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ profile: data })
+}
+
+export async function POST(request) {
+  const supabase = createSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const { full_name, occupation, desired_mrr, desired_hours } = body
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .upsert({
+      id: user.id,
+      full_name,
+      occupation,
+      desired_mrr,
+      desired_hours
+    }, { onConflict: 'id' })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ profile: data })
+}


### PR DESCRIPTION
## Summary
- add new `/api/profile` endpoint

## Testing
- `npm test` *(fails: getAIResponse)*
- `npm run lint` *(fails: prompts for config)*