### PR TITLE
Add user profile helpers

### DIFF
--- a/lib/utils/supabase.js
+++ b/lib/utils/supabase.js
@@ -452,6 +452,50 @@ export async function deleteThread(threadId) {
   }
 }
 
+export async function getUserProfile(userId) {
+  if (process.env.NODE_ENV !== "production") console.log('[Supabase] Fetching user profile for:', userId);
+
+  const supabase = createSupabaseClient();
+
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .single();
+
+  if (error) {
+    if (error.code !== 'PGRST116') {
+      if (process.env.NODE_ENV !== "production") console.error('[Supabase] Error fetching user profile:', error);
+      throw error;
+    }
+  }
+
+  if (process.env.NODE_ENV !== "production") console.log('[Supabase] User profile fetched:', data);
+
+  return data;
+}
+
+export async function upsertUserProfile(userId, data) {
+  if (process.env.NODE_ENV !== "production") console.log('[Supabase] Upserting user profile for:', userId);
+
+  const supabase = createSupabaseClient();
+
+  const { data: profile, error } = await supabase
+    .from('user_profiles')
+    .upsert({ user_id: userId, ...data }, { onConflict: 'user_id' })
+    .select()
+    .single();
+
+  if (error) {
+    if (process.env.NODE_ENV !== "production") console.error('[Supabase] Error upserting user profile:', error);
+    throw error;
+  }
+
+  if (process.env.NODE_ENV !== "production") console.log('[Supabase] User profile upserted:', profile);
+
+  return profile;
+}
+
 // ---------------------------------------------------------------------------
 // Back-compat helper aliases – older parts of the codebase still expect
 // `fetchThreads` to exist.  We now expose it as an alias to `getThreads` so the


### PR DESCRIPTION
## Summary
- add `getUserProfile` and `upsertUserProfile` helpers using `createBrowserClient`
- export the helpers for use by frontend

## Testing
- `npm test` *(fails: getAIResponse tests fail)*