### PR TITLE
Add memory tables and schemas

### DIFF
--- a/db/schema/index.js
+++ b/db/schema/index.js
@@ -2,3 +2,5 @@ export * from "./threads-schema";
 export * from "./messages-schema";
 export * from "./profiles-schema";
 // Include any other schemas exported from this directory
+export * from "./user-memories-schema";
+export * from "./memory-summaries-schema";

--- a/db/schema/memory-summaries-schema.js
+++ b/db/schema/memory-summaries-schema.js
@@ -1,0 +1,14 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const memorySummariesTable = pgTable("memory_summaries", {
+  user_id: text("user_id").primaryKey(),
+  summary: text("summary"),
+  updated_at: timestamp("updated_at").defaultNow()
+});
+
+export const getMemorySummariesTableWithTypescript = () => {
+  return {
+    $inferInsert: {},
+    $inferSelect: {}
+  };
+};

--- a/db/schema/user-memories-schema.js
+++ b/db/schema/user-memories-schema.js
@@ -1,0 +1,28 @@
+import { pgTable, text, timestamp, pgEnum } from "drizzle-orm/pg-core";
+import { threadsTable } from "./threads-schema";
+
+export const memoryTypeEnum = pgEnum("memory_type", [
+  "episodic",
+  "fact",
+  "preference",
+  "artefact"
+]);
+
+export const userMemoriesTable = pgTable("user_memories", {
+  id: text("id").defaultRandom().primaryKey(),
+  user_id: text("user_id").notNull(),
+  thread_id: text("thread_id")
+    .references(() => threadsTable.id, { onDelete: "cascade" })
+    .notNull(),
+  content: text("content").notNull(),
+  type: memoryTypeEnum("type").notNull(),
+  embedding: text("embedding"),
+  created_at: timestamp("created_at").defaultNow()
+});
+
+export const getUserMemoriesTableWithTypescript = () => {
+  return {
+    $inferInsert: {},
+    $inferSelect: {}
+  };
+};

--- a/supabase/migrations/20240617000000_add_memory_tables.sql
+++ b/supabase/migrations/20240617000000_add_memory_tables.sql
@@ -1,0 +1,102 @@
+-- Enable vector extension and add memory tables
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Enum type for memory categories
+CREATE TYPE memory_type AS ENUM ('episodic','fact','preference','artefact');
+
+-- Table storing individual user memories
+CREATE TABLE user_memories (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+    thread_id uuid REFERENCES threads(id) ON DELETE CASCADE,
+    content text NOT NULL,
+    type memory_type NOT NULL,
+    embedding vector(1536),
+    created_at timestamp with time zone DEFAULT now()
+);
+
+-- Table storing summary per user
+CREATE TABLE memory_summaries (
+    user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    summary text,
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE user_memories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memory_summaries ENABLE ROW LEVEL SECURITY;
+
+-- Policies for user_memories
+CREATE POLICY "Users can view their own memories"
+    ON user_memories FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own memories"
+    ON user_memories FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own memories"
+    ON user_memories FOR UPDATE
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own memories"
+    ON user_memories FOR DELETE
+    USING (auth.uid() = user_id);
+
+-- Policies for memory_summaries
+CREATE POLICY "Users can view their memory summaries"
+    ON memory_summaries FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their memory summaries"
+    ON memory_summaries FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their memory summaries"
+    ON memory_summaries FOR UPDATE
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their memory summaries"
+    ON memory_summaries FOR DELETE
+    USING (auth.uid() = user_id);
+
+-- Optional dev policies
+CREATE POLICY "Allow dev users to select user_memories"
+  ON user_memories
+  FOR SELECT
+  USING (user_id LIKE 'dev-user-%');
+
+CREATE POLICY "Allow dev users to insert user_memories"
+  ON user_memories
+  FOR INSERT
+  WITH CHECK (user_id LIKE 'dev-user-%');
+
+CREATE POLICY "Allow dev users to update user_memories"
+  ON user_memories
+  FOR UPDATE
+  USING (user_id LIKE 'dev-user-%');
+
+CREATE POLICY "Allow dev users to delete user_memories"
+  ON user_memories
+  FOR DELETE
+  USING (user_id LIKE 'dev-user-%');
+
+CREATE POLICY "Allow dev users to select memory_summaries"
+  ON memory_summaries
+  FOR SELECT
+  USING (user_id LIKE 'dev-user-%');
+
+CREATE POLICY "Allow dev users to insert memory_summaries"
+  ON memory_summaries
+  FOR INSERT
+  WITH CHECK (user_id LIKE 'dev-user-%');
+
+CREATE POLICY "Allow dev users to update memory_summaries"
+  ON memory_summaries
+  FOR UPDATE
+  USING (user_id LIKE 'dev-user-%');
+
+CREATE POLICY "Allow dev users to delete memory_summaries"
+  ON memory_summaries
+  FOR DELETE
+  USING (user_id LIKE 'dev-user-%');


### PR DESCRIPTION
## Summary
- add migration for user memories and summaries with RLS and dev policies
- define drizzle schemas for new tables
- export new schemas

## Testing
- `npm test` *(fails: @supabase/ssr requires project URL and API key)*