### PR TITLE
Add memory management support

### DIFF
--- a/app/api/memory/route.js
+++ b/app/api/memory/route.js
@@ -1,0 +1,66 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+function createSupabaseClient() {
+  const cookieStore = cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(name) {
+          return cookieStore.get(name)?.value;
+        },
+        set(name, value, options) {
+          cookieStore.set({ name, value, ...options });
+        },
+        remove(name, options) {
+          cookieStore.set({ name, value: '', ...options });
+        },
+      },
+    }
+  );
+}
+
+async function wipeMemories(supabase, userId) {
+  await supabase.from('messages').delete().eq('user_id', userId);
+  await supabase.from('threads').delete().eq('user_id', userId);
+}
+
+export async function GET() {
+  const supabase = createSupabaseClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from('messages')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('timestamp', { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ memories: data });
+}
+
+export async function DELETE() {
+  const supabase = createSupabaseClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    await wipeMemories(supabase, user.id);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/api/profile/route.js
+++ b/app/api/profile/route.js
@@ -33,7 +33,7 @@ export async function GET() {
 
   const { data, error } = await supabase
     .from('user_profiles')
-    .select('full_name, occupation, desired_mrr, desired_hours')
+    .select('full_name, occupation, desired_mrr, desired_hours, allow_memory')
     .eq('user_id', user.id)
     .single()
 
@@ -53,7 +53,7 @@ export async function POST(request) {
   }
 
   const body = await request.json()
-  const { full_name, occupation, desired_mrr, desired_hours } = body
+  const { full_name, occupation, desired_mrr, desired_hours, allow_memory } = body
 
   const { data, error } = await supabase
     .from('user_profiles')
@@ -62,7 +62,8 @@ export async function POST(request) {
       full_name,
       occupation,
       desired_mrr,
-      desired_hours
+      desired_hours,
+      allow_memory
     }, { onConflict: 'user_id' })
     .select()
     .single()

--- a/db/schema/profiles-schema.js
+++ b/db/schema/profiles-schema.js
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
 
 export const userProfilesTable = pgTable("user_profiles", {
   id: text("id").defaultRandom().primaryKey(),
@@ -7,6 +7,7 @@ export const userProfilesTable = pgTable("user_profiles", {
   occupation: text("occupation"),
   desired_mrr: text("desired_mrr"),
   desired_hours: text("desired_hours"),
+  allow_memory: boolean("allow_memory").default(true).notNull(),
   business_name: text("business_name"),
   business_type: text("business_type"),
   target_audience: text("target_audience"),

--- a/supabase/migrations/20240615000000_add_allow_memory.sql
+++ b/supabase/migrations/20240615000000_add_allow_memory.sql
@@ -1,0 +1,2 @@
+-- Add allow_memory column to user_profiles
+alter table public.user_profiles add column allow_memory boolean default true not null;


### PR DESCRIPTION
## Summary
- add `allow_memory` column to user_profiles schema and Supabase migration
- extend profile API route to handle `allow_memory`
- add memory API route for listing and wiping memories
- show memory toggle and memory actions on profile page

## Testing
- `npm test` *(fails: Supabase tests require project credentials)*
- `npm run lint` *(fails: prompts for configuration)*