### PR TITLE
Refactor memory utils

### DIFF
--- a/lib/utils/memory.js
+++ b/lib/utils/memory.js
@@ -1,26 +1,85 @@
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
+import { v4 as uuidv4 } from 'uuid';
 
-export async function saveMemory({ user_id, thread_id, content, embedding, memory_type }) {
-  const supabase = createServerClient(
+function createSupabaseClient() {
+  return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     { cookies }
   );
-
-  const { error } = await supabase.from('memories').insert({
-    user_id,
-    thread_id,
-    content,
-    embedding,
-    memory_type
-  });
-
-  if (error) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error('[saveMemory] Error inserting memory:', error);
-    }
-    throw error;
-  }
 }
+
+export async function saveMemory({ userId, threadId, content, type, embedding }) {
+  if (!userId) {
+    throw new Error('userId required');
+  }
+
+  const supabase = createSupabaseClient();
+
+  const { data, error } = await supabase
+    .from('user_memories')
+    .insert({
+      id: uuidv4(),
+      user_id: userId,
+      thread_id: threadId,
+      content,
+      type,
+      embedding
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function searchMemories(userId, embeddingVector, k = 5) {
+  const supabase = createSupabaseClient();
+  const { data, error } = await supabase.rpc('match_user_memories', {
+    query_embedding: embeddingVector,
+    match_count: k,
+    user_id: userId
+  });
+  if (error) throw error;
+  return data;
+}
+
+export async function getMemorySummary(userId) {
+  const supabase = createSupabaseClient();
+  const { data, error } = await supabase
+    .from('memory_summaries')
+    .select('summary')
+    .eq('user_id', userId)
+    .single();
+  if (error && error.code !== 'PGRST116') throw error;
+  return data ? data.summary : null;
+}
+
+export async function upsertMemorySummary(userId, summaryText) {
+  const supabase = createSupabaseClient();
+  const { data, error } = await supabase
+    .from('memory_summaries')
+    .upsert({ user_id: userId, summary: summaryText }, { onConflict: 'user_id' })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function wipeMemories(userId) {
+  const supabase = createSupabaseClient();
+  const { error: memError } = await supabase
+    .from('user_memories')
+    .delete()
+    .eq('user_id', userId);
+  if (memError) throw memError;
+  const { error: summaryError } = await supabase
+    .from('memory_summaries')
+    .delete()
+    .eq('user_id', userId);
+  if (summaryError) throw summaryError;
+  return true;
+}
+
 

--- a/lib/utils/supabase.js
+++ b/lib/utils/supabase.js
@@ -1,6 +1,12 @@
 import { createBrowserClient } from '@supabase/ssr';
 import { generateThreadTitle } from './thread';
-import { v4 as uuidv4 } from 'uuid';
+import {
+  saveMemory,
+  searchMemories,
+  getMemorySummary,
+  upsertMemorySummary,
+  wipeMemories,
+} from './memory';
 
 export const supabaseExports = {};
 
@@ -499,74 +505,6 @@ export async function upsertUserProfile(userId, data) {
   return profile;
 }
 
-export async function saveMemory({ userId, threadId, content, type, embedding }) {
-  if (!userId) {
-    throw new Error('userId required');
-  }
-  const supabase = createSupabaseClient();
-  const { data, error } = await supabase
-    .from('user_memories')
-    .insert({
-      id: uuidv4(),
-      user_id: userId,
-      thread_id: threadId,
-      content,
-      type,
-      embedding
-    })
-    .select()
-    .single();
-  if (error) throw error;
-  return data;
-}
-
-export async function searchMemories(userId, embeddingVector, k = 5) {
-  const supabase = createSupabaseClient();
-  const { data, error } = await supabase.rpc('match_user_memories', {
-    query_embedding: embeddingVector,
-    match_count: k,
-    user_id: userId
-  });
-  if (error) throw error;
-  return data;
-}
-
-export async function getMemorySummary(userId) {
-  const supabase = createSupabaseClient();
-  const { data, error } = await supabase
-    .from('user_memory_summaries')
-    .select('summary')
-    .eq('user_id', userId)
-    .single();
-  if (error && error.code !== 'PGRST116') throw error;
-  return data ? data.summary : null;
-}
-
-export async function upsertMemorySummary(userId, summaryText) {
-  const supabase = createSupabaseClient();
-  const { data, error } = await supabase
-    .from('user_memory_summaries')
-    .upsert({ user_id: userId, summary: summaryText }, { onConflict: 'user_id' })
-    .select()
-    .single();
-  if (error) throw error;
-  return data;
-}
-
-export async function wipeMemories(userId) {
-  const supabase = createSupabaseClient();
-  const { error: memError } = await supabase
-    .from('user_memories')
-    .delete()
-    .eq('user_id', userId);
-  if (memError) throw memError;
-  const { error: summaryError } = await supabase
-    .from('user_memory_summaries')
-    .delete()
-    .eq('user_id', userId);
-  if (summaryError) throw summaryError;
-  return true;
-}
 
 export function isProfileComplete(profile) {
   if (!profile) return false;
@@ -585,4 +523,12 @@ export async function isUserProfileComplete(userId) {
 // import works no matter which name is used.
 // ---------------------------------------------------------------------------
 
-export { getThreads as fetchThreads, supabaseExports };
+export {
+  getThreads as fetchThreads,
+  supabaseExports,
+  saveMemory,
+  searchMemories,
+  getMemorySummary,
+  upsertMemorySummary,
+  wipeMemories,
+};


### PR DESCRIPTION
## Summary
- consolidate memory helpers in `lib/utils/memory.js`
- remove duplicate logic from `lib/utils/supabase.js`
- update API route to use new helpers

## Testing
- `npm test` *(fails: await isn't allowed in non-async function)*