### PR TITLE
Add memory helper and classification tests

### DIFF
--- a/__tests__/classifyMemory.test.js
+++ b/__tests__/classifyMemory.test.js
@@ -1,0 +1,60 @@
+const mockOpenAI = jest.fn(() => ({
+  chat: { completions: { create: jest.fn() } },
+  embeddings: { create: jest.fn() }
+}))
+jest.mock('openai', () => ({ OpenAI: mockOpenAI }))
+jest.mock('@anthropic-ai/sdk', () => ({ __esModule: true, default: jest.fn() }))
+jest.mock('next/server', () => ({ __esModule: true, NextResponse: { json: jest.fn() } }))
+jest.mock('next/headers', () => ({ __esModule: true, cookies: jest.fn() }))
+jest.mock('@supabase/ssr', () => ({ __esModule: true, createServerClient: jest.fn() }))
+
+global.Response = class {}
+
+let openaiInstance
+
+const saveMemoryMock = jest.fn()
+jest.mock('@/lib/utils/memory', () => ({
+  saveMemory: (...args) => saveMemoryMock(...args)
+}))
+
+describe('classifyAndSaveMemory', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+  })
+
+  it('saves memory when classification allows', async () => {
+    const { classifyAndSaveMemory } = await import('@/app/api/chat/route')
+    openaiInstance = mockOpenAI.mock.results[0].value
+    openaiInstance.chat.completions.create.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify({ should_write_memory: true, memory_type: 'note' }) } }]
+    })
+    openaiInstance.embeddings.create.mockResolvedValue({ data: [{ embedding: [0.2] }] })
+    await classifyAndSaveMemory('hello', 't1', 'u1')
+    expect(openaiInstance.chat.completions.create).toHaveBeenCalledWith({
+      model: 'gpt-4o',
+      messages: expect.any(Array),
+      temperature: 0,
+      response_format: { type: 'json_object' }
+    })
+    expect(openaiInstance.embeddings.create).toHaveBeenCalledWith({ model: 'text-embedding-3-small', input: 'hello' })
+    expect(saveMemoryMock).toHaveBeenCalledWith({
+      user_id: 'u1',
+      thread_id: 't1',
+      content: 'hello',
+      embedding: [0.2],
+      memory_type: 'note'
+    })
+  })
+
+  it('skips saving when classification disallows', async () => {
+    const { classifyAndSaveMemory } = await import('@/app/api/chat/route')
+    openaiInstance = mockOpenAI.mock.results[0].value
+    openaiInstance.chat.completions.create.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify({ should_write_memory: false }) } }]
+    })
+    await classifyAndSaveMemory('hello', 't1', 'u1')
+    expect(openaiInstance.embeddings.create).not.toHaveBeenCalled()
+    expect(saveMemoryMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/memoryHelpers.test.js
+++ b/__tests__/memoryHelpers.test.js
@@ -1,0 +1,41 @@
+import { saveMemory, searchMemories } from '@/lib/utils/supabase'
+
+jest.mock('@supabase/ssr', () => ({
+  createBrowserClient: jest.fn()
+}))
+
+jest.mock('uuid', () => ({ v4: jest.fn(() => 'uuid-123') }))
+
+const fromMock = jest.fn()
+const insertMock = jest.fn(() => ({ select: () => ({ single: () => Promise.resolve({ data: { id: 'uuid-123' }, error: null }) }) }))
+const rpcMock = jest.fn(() => Promise.resolve({ data: [{ id: 'm1' }], error: null }))
+
+beforeEach(() => {
+  require('@supabase/ssr').createBrowserClient.mockReturnValue({
+    from: jest.fn(() => ({ insert: insertMock })),
+    rpc: rpcMock
+  })
+})
+
+describe('memory helpers', () => {
+  it('saveMemory inserts into user_memories', async () => {
+    await saveMemory({ userId: 'u1', threadId: 't1', content: 'text', type: 'general', embedding: [1] })
+    expect(insertMock).toHaveBeenCalledWith({
+      id: 'uuid-123',
+      user_id: 'u1',
+      thread_id: 't1',
+      content: 'text',
+      type: 'general',
+      embedding: [1]
+    })
+  })
+
+  it('searchMemories calls match_user_memories RPC', async () => {
+    await searchMemories('u1', [0, 1], 3)
+    expect(rpcMock).toHaveBeenCalledWith('match_user_memories', {
+      query_embedding: [0, 1],
+      match_count: 3,
+      user_id: 'u1'
+    })
+  })
+})

--- a/__tests__/supabase.test.js
+++ b/__tests__/supabase.test.js
@@ -36,7 +36,13 @@ describe('supabase utils', () => {
     expect(isProfileComplete(profile)).toBe(true)
   })
 
-integration
+  it('isUserProfileComplete uses getUserProfile', async () => {
+    jest.spyOn(supabaseExports, 'getUserProfile').mockResolvedValue({
+      full_name: 'Test',
+      occupation: 'Dev',
+      desired_mrr: '1',
+      desired_hours: '2'
+    })
     await expect(isUserProfileComplete('user')).resolves.toBe(true)
     expect(supabaseExports.getUserProfile).toHaveBeenCalledWith('user')
   })

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -2463,7 +2463,7 @@ function processFileSearchResults(fileSearchCall) {
 }
 
 // Analyze assistant text and store as memory without blocking the response
-async function classifyAndSaveMemory(text, threadId, userId) {
+export async function classifyAndSaveMemory(text, threadId, userId) {
   try {
     const classificationPrompt = [
       { role: 'system', content: 'Decide if the following assistant message should be saved as a memory. Return JSON {"should_write_memory": boolean, "memory_type": "short type"}. Use "general" if unsure.' },


### PR DESCRIPTION
## Summary
- fix broken test in supabase.test
- export `classifyAndSaveMemory`
- test `saveMemory` and `searchMemories`
- test `classifyAndSaveMemory`

## Testing
- `npm test --silent`