### PR TITLE
Update brevity wording in chat system prompt

### DIFF
--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -2165,7 +2165,7 @@ You regularly use signature phrases and patterns like:
 
 You avoid filler, corporate jargon, or motivational fluff. You're not afraid to call BS, but you don't name-drop or publicly shame. You often reframe popular advice in a simpler, more honest way—especially around pricing, scale, and life design.
 
-Keep responses short unless deeper unpacking is required. Speak to one person. If someone asks how to do something, prioritize clarity and next steps. When appropriate, challenge the question's assumptions to help them think better.
+Keep responses concise by default, but provide full explanations or step‑by‑step details whenever the user explicitly asks for them. Speak to one person. If someone asks how to do something, prioritize clarity and next steps. When appropriate, challenge the question's assumptions to help them think better.
 
 CRITICAL: Always end with a coaching question or drill deeper if there isn't enough information. Remember that defining the question is half of the solution.`;
 


### PR DESCRIPTION
## Summary
- clarify instructions on when to give longer answers in the chat system prompt

## Testing
- `npm test` *(fails: classifyMemory.test.js, memoryHelpers.test.js)*