### PR TITLE
Add snippet highlighting feature

### DIFF
--- a/app/snippets/page.js
+++ b/app/snippets/page.js
@@ -1,0 +1,54 @@
+"use client";
+import useSnippets from '@/hooks/use-snippets';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import SnippetModal from '@/components/SnippetModal';
+
+export default function SnippetsPage() {
+  const { snippets, deleteSnippet, updateSnippet } = useSnippets();
+  const [editing, setEditing] = useState(null);
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <h1 className="text-xl font-semibold mb-4">Snippets</h1>
+      {snippets.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No snippets saved.</p>
+      ) : (
+        <div className="space-y-4">
+          {snippets.map((snip) => (
+            <Card key={snip.id}>
+              <CardHeader className="flex items-start justify-between">
+                <div>
+                  <CardTitle className="text-sm">{snip.label || 'Untitled'}</CardTitle>
+                  <p className="text-xs text-muted-foreground">{new Date(snip.createdAt).toLocaleString()}</p>
+                </div>
+                <div className="flex gap-2">
+                  <Button variant="ghost" size="sm" onClick={() => setEditing(snip)}>Edit</Button>
+                  <Button variant="ghost" size="sm" onClick={() => deleteSnippet(snip.id)}>Delete</Button>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <p className="text-sm whitespace-pre-wrap">{snip.text}</p>
+                {snip.note && <p className="text-xs text-muted-foreground">{snip.note}</p>}
+                {snip.context && <p className="text-xs text-muted-foreground">From: {snip.context}</p>}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+      {editing && (
+        <SnippetModal
+          open={true}
+          text={editing.text}
+          initial={{ label: editing.label, note: editing.note }}
+          onClose={() => setEditing(null)}
+          onSave={({ label, note }) => {
+            updateSnippet(editing.id, { label, note });
+            setEditing(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/Message.js
+++ b/components/Message.js
@@ -1,9 +1,13 @@
+"use client";
 import { MessageCircle, User, Clock, Bot } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { format } from "date-fns";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useState } from 'react';
+import useSnippets from '@/hooks/use-snippets';
+import SnippetModal from './SnippetModal';
 
 // Add a component for rendering markdown messages
 function MarkdownMessage({ content }) {
@@ -21,10 +25,38 @@ export default function Message({ message }) {
   const isUser = message.role === 'user';
   const timestamp = message.timestamp || new Date();
   const formattedTime = format(new Date(timestamp), 'HH:mm');
+  const { addSnippet } = useSnippets();
+  const [selection, setSelection] = useState(null);
+  const [menuPos, setMenuPos] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+
+  const handleMouseUp = (e) => {
+    const sel = window.getSelection();
+    const text = sel.toString().trim();
+    if (text) {
+      const rect = sel.getRangeAt(0).getBoundingClientRect();
+      setSelection(text);
+      setMenuPos({ x: rect.right, y: rect.bottom });
+    } else {
+      setMenuPos(null);
+    }
+  };
+
+  const saveSnippet = ({ label, note }) => {
+    addSnippet({
+      id: Date.now().toString(),
+      text: selection,
+      label,
+      note,
+      context: message.thread_id ? `chat ${message.thread_id}` : 'chat',
+      createdAt: new Date().toISOString(),
+    });
+    setSelection(null);
+  };
 
   return (
     <div className={cn(
-      "flex items-start gap-3 max-w-[85%] group relative py-2", 
+      "flex items-start gap-3 max-w-[85%] group relative py-2",
       isUser ? "self-end ml-auto" : "self-start mr-auto"
     )}>
       {!isUser && (
@@ -35,12 +67,15 @@ export default function Message({ message }) {
         </Avatar>
       )}
       
-      <div className={cn(
-        "rounded-2xl p-3 text-sm", 
-        isUser 
-          ? "bg-primary text-primary-foreground rounded-tr-none" 
-          : "bg-muted text-foreground rounded-tl-none overflow-auto"
-      )}>
+      <div
+        onMouseUp={handleMouseUp}
+        className={cn(
+          "rounded-2xl p-3 text-sm",
+          isUser
+            ? "bg-primary text-primary-foreground rounded-tr-none"
+            : "bg-muted text-foreground rounded-tl-none overflow-auto"
+        )}
+      >
         {/* Render content with markdown for assistant messages or as text for users */}
         <div className={isUser ? "whitespace-pre-wrap" : ""}>
           {message.isJSX ? (
@@ -68,6 +103,23 @@ export default function Message({ message }) {
           </AvatarFallback>
         </Avatar>
       )}
+      {menuPos && selection && (
+        <div
+          className="absolute z-50 bg-background border rounded shadow px-2 py-1 text-xs"
+          style={{ top: menuPos.y, left: menuPos.x }}
+        >
+          <button onClick={() => { setShowModal(true); setMenuPos(null); }}>Save as Snippet</button>
+        </div>
+      )}
+      {showModal && selection && (
+        <SnippetModal
+          open={true}
+          text={selection}
+          onClose={() => { setShowModal(false); setSelection(null); }}
+          onSave={(data) => { saveSnippet(data); setShowModal(false); }}
+        />
+      )}
     </div>
   );
-} 
+}
+

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -296,6 +296,14 @@ export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats
                 <Settings className="h-4 w-4 mr-2" />
                 Settings
               </Button>
+              <Button
+                variant="ghost"
+                className="w-full justify-start px-2 h-8 text-sm mt-2 hover:bg-muted"
+                onClick={() => router.push('/snippets')}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                Snippets
+              </Button>
             </>
           ) : (
             <Button className="w-full" onClick={() => router.push('/login')}>

--- a/components/SnippetModal.js
+++ b/components/SnippetModal.js
@@ -1,0 +1,44 @@
+"use client";
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function SnippetModal({ open, onClose, onSave, text, initial }) {
+  const [label, setLabel] = useState(initial?.label || "");
+  const [note, setNote] = useState(initial?.note || "");
+
+  useEffect(() => {
+    if (open) {
+      setLabel(initial?.label || "");
+      setNote(initial?.note || "");
+    }
+  }, [open, initial]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background rounded-lg p-4 w-[90%] max-w-sm">
+        <h2 className="text-base font-semibold mb-2">Save Snippet</h2>
+        <p className="text-sm mb-3 whitespace-pre-wrap max-h-40 overflow-y-auto border p-2 rounded">
+          {text}
+        </p>
+        <input
+          className="w-full border rounded px-2 py-1 text-sm mb-2"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="Label"
+        />
+        <textarea
+          className="w-full border rounded px-2 py-1 text-sm"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Optional note or tag"
+        />
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button onClick={() => onSave({ label, note })}>Save</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/hooks/use-snippets.js
+++ b/hooks/use-snippets.js
@@ -1,0 +1,37 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/components/AuthProvider';
+
+export default function useSnippets() {
+  const { user } = useAuth();
+  const [snippets, setSnippets] = useState([]);
+
+  // load from localStorage
+  useEffect(() => {
+    if (!user?.id) return;
+    try {
+      const saved = localStorage.getItem(`snippets_${user.id}`);
+      if (saved) setSnippets(JSON.parse(saved));
+    } catch (e) {}
+  }, [user?.id]);
+
+  // persist to localStorage
+  useEffect(() => {
+    if (!user?.id) return;
+    localStorage.setItem(`snippets_${user.id}`, JSON.stringify(snippets));
+  }, [snippets, user?.id]);
+
+  const addSnippet = (snippet) => {
+    setSnippets((prev) => [snippet, ...prev]);
+  };
+
+  const updateSnippet = (id, updates) => {
+    setSnippets((prev) => prev.map((s) => (s.id === id ? { ...s, ...updates } : s)));
+  };
+
+  const deleteSnippet = (id) => {
+    setSnippets((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  return { snippets, addSnippet, updateSnippet, deleteSnippet };
+}


### PR DESCRIPTION
## Summary
- enable text highlighting and snippet creation in Message component
- persist user snippets locally with a new `useSnippets` hook
- present a modal for labeling snippets
- add a Snippets page for viewing and editing saved items
- link Snippets page from the sidebar

## Testing
- `npm test` *(fails: Syntax Error in app/api/chat/route.js)*

------
https://chatgpt.com/codex/tasks/task_e_683a5d1571308332a7023031bb724ba1