### PR TITLE
Add chat ID routing

### DIFF
--- a/app/chat/[id]/page.js
+++ b/app/chat/[id]/page.js
@@ -1,0 +1,10 @@
+import ChatLayout from "@/components/ChatLayout";
+
+export default function ChatPage({ params }) {
+  const { id } = params;
+  return (
+    <main className="flex h-screen">
+      <ChatLayout initialChatId={id} />
+    </main>
+  );
+}

--- a/components/ChatLayout.js
+++ b/components/ChatLayout.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import Sidebar from "./Sidebar";
 import ChatArea from "./ChatArea";
 import ProfileModal from "./ProfileModal";
@@ -18,7 +18,7 @@ const isValidUUID = (id) => {
   return uuidV4Pattern.test(id);
 };
 
-export default function ChatLayout() {
+export default function ChatLayout({ initialChatId } = {}) {
   const [selectedTool, setSelectedTool] = useState(null);
   const [chats, setChats] = useState([]);
   const [currentChat, setCurrentChat] = useState(null);
@@ -29,6 +29,7 @@ export default function ChatLayout() {
   const { user, loading: authLoading } = useAuth();
   const { toast } = useToast();
   const router = useRouter();
+  const pathname = usePathname();
 
   // Keep track of temporary to permanent ID mappings
   const [idMappings, setIdMappings] = useState({});
@@ -238,6 +239,25 @@ export default function ChatLayout() {
       createDefaultChat();
     }
   }, [user?.id, toast]);
+
+  // When chats are loaded, select chat based on initialChatId if provided
+  useEffect(() => {
+    if (initialChatId && chats.length > 0) {
+      const found = chats.find(c => c.id === initialChatId);
+      if (found && currentChat?.id !== found.id) {
+        setCurrentChatWithTracking(found);
+      }
+    }
+  }, [initialChatId, chats]);
+
+  // Redirect to chat route when currentChat changes
+  useEffect(() => {
+    if (currentChat?.id) {
+      if (pathname !== `/chat/${currentChat.id}`) {
+        router.replace(`/chat/${currentChat.id}`);
+      }
+    }
+  }, [currentChat?.id, pathname]);
 
   // New useEffect to synchronize selectedTool with currentChat.tool_id
   useEffect(() => {

--- a/components/NotificationBell.js
+++ b/components/NotificationBell.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { Bell, CheckCircle2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -12,6 +13,7 @@ export default function NotificationBell({ chats, setCurrentChat, currentChat })
   const [showNotifications, setShowNotifications] = useState(false);
   const [processedChats, setProcessedChats] = useState(new Set());
   const { user } = useAuth();
+  const router = useRouter();
 
   // Load notifications and processed chats from localStorage on mount
   useEffect(() => {
@@ -126,6 +128,7 @@ export default function NotificationBell({ chats, setCurrentChat, currentChat })
     const targetChat = chats.find(c => c.id === notification.chatId);
     if (targetChat) {
       setCurrentChat(targetChat);
+      router.push('/chat/' + targetChat.id);
       // Remove the notification instead of just marking as read
       removeNotification(notification.id);
       setShowNotifications(false);

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -81,6 +81,7 @@ export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats
     setCurrentChat(newChat);
     setSelectedTool(toolId);
     setIsMobileOpen(false);
+    router.push('/chat/' + newChat.id);
   };
 
   const handleToolClick = (toolId) => {
@@ -88,6 +89,7 @@ export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats
     if (existingChat) {
       setCurrentChat(existingChat);
       setSelectedTool(toolId);
+      router.push('/chat/' + existingChat.id);
     } else {
       handleNewChat(toolId);
     }
@@ -258,6 +260,7 @@ export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats
                         onClick={() => {
                           setCurrentChat(chat);
                           setSelectedTool(chat.tool_id || null);
+                          router.push('/chat/' + chat.id);
                         }}
                       >
                         {getChatIcon(chat)}


### PR DESCRIPTION
## Summary
- create app/chat/[id] route to load ChatLayout with a chat id
- update Sidebar and NotificationBell navigation to use new chat URL
- redirect to chat url whenever current chat changes

## Testing
- `npm test` *(fails: SyntaxError and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_684751e5e35c8332bd1eb5ad2c00c887