### PR TITLE
Fix chat creation flags

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -44,7 +44,7 @@ const toolIcons = {
   'workshop-generator': PenTool
 };
 
-export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats, currentChat, setCurrentChat, isLoading, onShowProfile, profileComplete }) {
+export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats, currentChat, setCurrentChat, isLoading, onShowProfile, profileComplete, setIsNewChat, setIsCurrentChatToolInit }) {
   const { user, signOut } = useAuth();
   const router = useRouter();
   const [expandedChats, setExpandedChats] = useState(false);
@@ -77,6 +77,12 @@ export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats
     const newChat = createNewThread(toolId);
     console.log('[Sidebar] Created new chat object:', JSON.stringify(newChat));
     console.log(`[Sidebar] Attempting to set current chat. Tool ID passed: ${toolId}, New chat tool_id: ${newChat.tool_id}`);
+    newChat.isNewChat = true;
+    if (toolId) {
+      newChat.isCurrentChatToolInit = true;
+      if (setIsCurrentChatToolInit) setIsCurrentChatToolInit(true);
+    }
+    if (setIsNewChat) setIsNewChat(true);
     setChats(prevChats => [newChat, ...prevChats]);
     setCurrentChat(newChat);
     setSelectedTool(toolId);


### PR DESCRIPTION
## Summary
- track `isNewChat` and `isCurrentChatToolInit` in `ChatLayout`
- preserve chats with these flags when loading from Supabase
- expose new flag setters to `Sidebar`
- mark new chats accordingly in `Sidebar` and default chat creation

## Testing
- `npm test` *(fails: SyntaxError in Jest due to ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_6847521f1474833285643a6531b80bda