### PR TITLE
Resolve chat route conflicts and enhance PostHog hook

### DIFF
--- a/app/chat/page.js
+++ b/app/chat/page.js
@@ -1,0 +1,9 @@
+import ChatLayout from "@/components/ChatLayout";
+
+export default function ChatHomePage() {
+  return (
+    <main className="flex h-screen">
+      <ChatLayout />
+    </main>
+  );
+}

--- a/components/ChatArea.js
+++ b/components/ChatArea.js
@@ -775,6 +775,15 @@ export default function ChatArea({ selectedTool, currentChat, setCurrentChat, ch
         alert("Cannot send message: No active chat selected."); // User feedback
         return;
     }
+
+    // Track message attempt once we know there's a chat and input
+    if (trimmedInput) {
+      track('chat_message_sent', {
+        chatId: currentChat.id,
+        toolId: selectedTool,
+        length: trimmedInput.length
+      });
+    }
     
     // Prevent submission if loading
     if (!trimmedInput || isLoading || isResponseLoading || isInitiating) {

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -37,6 +37,7 @@ import { createNewThread } from '@/lib/utils/thread';
 import { deleteThread } from '@/lib/utils/supabase';
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { usePostHog } from '@/hooks/use-posthog';
 
 // Tool icons mapping
 const toolIcons = {
@@ -47,6 +48,7 @@ const toolIcons = {
 export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats, currentChat, setCurrentChat, isLoading, onShowProfile, profileComplete, setIsNewChat, setIsCurrentChatToolInit }) {
   const { user, signOut } = useAuth();
   const router = useRouter();
+  const { track } = usePostHog();
   const [expandedChats, setExpandedChats] = useState(false);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const INITIAL_CHAT_COUNT = 6;
@@ -88,6 +90,7 @@ export default function Sidebar({ selectedTool, setSelectedTool, chats, setChats
     setSelectedTool(toolId);
     setIsMobileOpen(false);
     router.push('/chat/' + newChat.id);
+    track('chat_created', { chatId: newChat.id, toolId });
   };
 
   const handleToolClick = (toolId) => {


### PR DESCRIPTION
## Summary
- add missing `/chat` route
- capture message and chat creation events with PostHog

## Testing
- `npm test` *(fails: SyntaxError Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684754d518d88332b53bbf4107f39de1