### PR TITLE
Centralize Supabase server client helper

### DIFF
--- a/app/api/memory/route.js
+++ b/app/api/memory/route.js
@@ -1,26 +1,8 @@
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createServerClientWithCookies } from '@/lib/utils/supabaseServer';
 import { NextResponse } from 'next/server';
 
 function createSupabaseClient() {
-  const cookieStore = cookies();
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    {
-      cookies: {
-        get(name) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name, value, options) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name, options) {
-          cookieStore.set({ name, value: '', ...options });
-        },
-      },
-    }
-  );
+  return createServerClientWithCookies();
 }
 
 async function wipeMemories(supabase, userId) {

--- a/app/api/profile/route.js
+++ b/app/api/profile/route.js
@@ -1,26 +1,8 @@
-import { createServerClient } from '@supabase/ssr'
-import { cookies } from 'next/headers'
+import { createServerClientWithCookies } from '@/lib/utils/supabaseServer'
 import { NextResponse } from 'next/server'
 
 function createSupabaseClient() {
-  const cookieStore = cookies()
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    {
-      cookies: {
-        get(name) {
-          return cookieStore.get(name)?.value
-        },
-        set(name, value, options) {
-          cookieStore.set({ name, value, ...options })
-        },
-        remove(name, options) {
-          cookieStore.set({ name, value: '', ...options })
-        }
-      }
-    }
-  )
+  return createServerClientWithCookies()
 }
 
 export async function GET() {

--- a/app/api/update-thread-metadata/route.js
+++ b/app/api/update-thread-metadata/route.js
@@ -1,27 +1,8 @@
 import { NextResponse } from 'next/server';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createServerClientWithCookies } from '@/lib/utils/supabaseServer';
 
 const createSupabaseClient = () => {
-  const cookieStore = cookies();
-  
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    {
-      cookies: {
-        get(name) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name, value, options) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name, options) {
-          cookieStore.set({ name, value: '', ...options });
-        },
-      },
-    }
-  );
+  return createServerClientWithCookies();
 };
 
 export async function POST(request) {

--- a/lib/utils/supabaseServer.js
+++ b/lib/utils/supabaseServer.js
@@ -1,0 +1,32 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export const createServerClientWithCookies = () => {
+  const cookieStore = cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        set(name, value, options) {
+          try {
+            cookieStore.set({ name, value, ...options })
+          } catch (error) {
+            // ignore cookie errors (e.g., during hot reload)
+          }
+        },
+        remove(name, options) {
+          try {
+            cookieStore.set({ name, value: '', ...options })
+          } catch (error) {
+            // ignore cookie errors (e.g., during hot reload)
+          }
+        }
+      }
+    }
+  )
+}


### PR DESCRIPTION
## Summary
- add `createServerClientWithCookies` helper
- use the helper in profile, memory and update-thread-metadata API routes

## Testing
- `npm test` *(fails: Jest encountered unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_68478a91fb688332ba908a1a092b33ae