### PR TITLE
Remove duplicate thread title function

### DIFF
--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getUserProfile } from '@/lib/utils/supabase';
 import { buildProfileContext } from '@/lib/utils/ai';
 import { createSessionSummary, getCoachingContext, getMessageCount, createToolMemorySummary } from '@/lib/utils/memory';
+import { generateThreadTitle } from '@/lib/utils/thread';
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
@@ -201,31 +202,6 @@ function calculateQuestionsAnswered(collectedAnswers, tool = 'hybrid-offer') {
   return count;
 }
 
-// Add this function to generate appropriate thread titles
-function generateThreadTitle(message) {
-  if (!message || !message.content) {
-    return "New conversation";
-  }
-  
-  // Truncate and clean the message to create a title
-  const maxLength = 30;
-  let title = message.content.trim();
-  
-  // Remove any newlines or extra whitespace
-  title = title.replace(/\s+/g, ' ');
-  
-  if (title.length > maxLength) {
-    // Cut at the last complete word within maxLength
-    title = title.substr(0, maxLength).split(' ').slice(0, -1).join(' ') + '...';
-  }
-  
-  console.log('[Chat API] Generated title from message:', {
-    original: message.content.substring(0, 50) + (message.content.length > 50 ? '...' : ''),
-    generated: title
-  });
-  
-  return title || "New conversation";
-}
 
 // Add a function to generate workshop HTML from template using AI
 async function generateWorkshopHTML(collectedAnswers) {

--- a/lib/utils/thread.js
+++ b/lib/utils/thread.js
@@ -47,4 +47,7 @@ export function generateThreadTitle(firstMessage) {
   });
   
   return title || "New conversation";
-} 
+}
+
+export { generateThreadTitle }
+


### PR DESCRIPTION
## Summary
- export `generateThreadTitle` helper
- import the helper in the chat API route
- remove duplicate implementation in API

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run lint` *(interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68478a948e6083329eb7ad701378ef81