### PR TITLE
Allow custom toast timeout

### DIFF
--- a/components/Chat.js
+++ b/components/Chat.js
@@ -85,6 +85,7 @@ export default function Chat({ thread: initialThread, onThreadUpdate }) {
           title: "Authentication Warning",
           description: "You appear to be using the app without being logged in. Your chats may not be saved.",
           variant: "destructive",
+          removeDelay: 10000,
         });
       }
     };
@@ -177,6 +178,7 @@ export default function Chat({ thread: initialThread, onThreadUpdate }) {
         title: "Error",
         description: `Failed to start the conversation: ${error.message}`,
         variant: "destructive",
+        removeDelay: 10000,
       });
       setError(error.message);
     } finally {
@@ -295,6 +297,7 @@ export default function Chat({ thread: initialThread, onThreadUpdate }) {
         title: "Error",
         description: `Failed to start a new chat: ${error.message}`,
         variant: "destructive",
+        removeDelay: 10000,
       });
       setError(error.message);
       return null;
@@ -384,7 +387,8 @@ export default function Chat({ thread: initialThread, onThreadUpdate }) {
         toast({
           variant: "destructive",
           title: "Error",
-          description: `Failed to get AI response: ${err.message}`
+          description: `Failed to get AI response: ${err.message}`,
+          removeDelay: 10000,
         });
       } finally {
         setIsLoading(false);
@@ -498,7 +502,8 @@ export default function Chat({ thread: initialThread, onThreadUpdate }) {
       toast({
         variant: "destructive",
         title: "Error",
-        description: `Failed to get AI response: ${err.message}`
+        description: `Failed to get AI response: ${err.message}`,
+        removeDelay: 10000,
       });
     } finally {
       setIsLoading(false);

--- a/components/ChatLayout.js
+++ b/components/ChatLayout.js
@@ -230,6 +230,7 @@ export default function ChatLayout({ initialChatId } = {}) {
           title: "Error",
           description: "Failed to load your conversations. Please try again.",
           variant: "destructive",
+          removeDelay: 10000,
         });
         
         // Create a default chat when there's an error loading


### PR DESCRIPTION
## Summary
- make toast removal delay customizable with a shorter default
- show longer error toasts in Chat components

## Testing
- `npm test` *(fails: SyntaxError - Cannot use import statement outside a module)*
- `npm run lint` *(fails: attempted to launch interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68478ab607f883329095f244e208cf7b