### PR TITLE
Fix chat route supabase client

### DIFF
--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -1,7 +1,6 @@
 import { OpenAI } from 'openai';
 import Anthropic from '@anthropic-ai/sdk';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createServerClientWithCookies } from '@/lib/utils/supabaseServer';
 import { NextResponse } from 'next/server';
 import { TOOLS } from '@/lib/config/tools';
 import { hybridOfferQuestions, workshopQuestions } from '@/lib/config/questions';
@@ -1067,18 +1066,7 @@ export async function POST(request) {
     }
 
     // Initialize Supabase client early, before any operations that might use it
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      {
-        cookies: {
-          get(name) { return cookieStore.get(name)?.value; },
-          set(name, value, options) { cookieStore.set({ name, value, ...options }); },
-          remove(name, options) { cookieStore.set({ name, value: '', ...options }); },
-        },
-      }
-    );
+    const supabase = createServerClientWithCookies();
 
     // Get the authenticated user
     const { data: { user } } = await supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- use createServerClientWithCookies in chat route

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm test` *(fails to run due to Jest config and environment)*

------
https://chatgpt.com/codex/tasks/task_e_68478dd174148332a4e70de4eaba7912