### PR TITLE
Fix bottom-up chat message scrolling

### DIFF
--- a/components/Chat.js
+++ b/components/Chat.js
@@ -188,14 +188,14 @@ export default function Chat({ thread: initialThread, onThreadUpdate }) {
   };
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, [messages]);
 
   // Add a separate effect to scroll when loading state changes
   useEffect(() => {
     if (isLoading) {
       if (process.env.NODE_ENV !== "production") console.log('[Chat] Loading state changed, scrolling to bottom');
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   }, [isLoading]);
 
@@ -556,7 +556,7 @@ export default function Chat({ thread: initialThread, onThreadUpdate }) {
       {tool && <ToolProgress tool={tool} messages={messages} thread={thread} />}
       
       <ScrollArea className="flex-grow p-6">
-        <div className="space-y-6 max-w-3xl mx-auto">
+        <div className="flex flex-col-reverse space-y-reverse space-y-6 max-w-3xl mx-auto pt-32">
           {messages.length === 0 && (
             <div className="flex flex-col items-center justify-center h-40 text-muted-foreground">
               <RefreshCw className="h-8 w-8 mb-2 animate-spin-slow" />
@@ -567,9 +567,12 @@ export default function Chat({ thread: initialThread, onThreadUpdate }) {
             </div>
           )}
           
-          {messages.map((msg) => (
-            <Message key={msg.id || msg.tempId || messages.indexOf(msg)} message={msg} />
-          ))}
+          {messages
+            .slice()
+            .reverse()
+            .map((msg, index, arr) => (
+              <Message key={msg.id || msg.tempId || index} message={msg} />
+            ))}
           
           {/* Use the new LoadingMessage component with explicit response loading state */}
           {isResponseLoading && <LoadingMessage />}

--- a/components/ChatArea.js
+++ b/components/ChatArea.js
@@ -1839,7 +1839,7 @@ export default function ChatArea({ selectedTool, currentChat, setCurrentChat, ch
         className="flex-1 overflow-y-auto"
       >
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-col space-y-4 sm:space-y-6 py-4 sm:py-8 pb-32">
+          <div className="flex flex-col-reverse space-y-reverse space-y-4 sm:space-y-6 py-4 sm:py-8 pt-32">
             {/* First message or empty state when no messages */}
             {!currentChat?.messages?.length ? (
               <div className="flex items-center justify-center min-h-[60vh]">
@@ -1855,7 +1855,7 @@ export default function ChatArea({ selectedTool, currentChat, setCurrentChat, ch
                 </div>
               </div>
             ) : (
-              currentChat.messages
+              const filteredMessages = currentChat.messages
                 .filter((message) => {
                   // Filter out document generation status messages if document is already complete
                   const isGenerationStatus = typeof message.content === 'string' && 
@@ -1879,10 +1879,14 @@ export default function ChatArea({ selectedTool, currentChat, setCurrentChat, ch
                   }
                   
                   return true;
-                })
-                .map((message, index, filteredArray) => {
-                  // Check if this is the last message in the filtered array
-                  const isLastMessage = index === filteredArray.length - 1;
+                });
+
+              filteredMessages
+                .slice()
+                .reverse()
+                .map((message, index, reversedArray) => {
+                  // In the reversed array, index 0 is the last message
+                  const isLastMessage = index === 0;
                   
                   return (
                     <div


### PR DESCRIPTION
## Summary
- render chat message lists using `flex-col-reverse`
- reverse messages in the React render loop
- keep scroll pinned to the start in Chat.js and ChatArea.js

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run lint` *(failed: asked interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68478eadabf48332b2672543a1d25191